### PR TITLE
image tag fix for globex-ui

### DIFF
--- a/roles/globex-ui/defaults/main.yml
+++ b/roles/globex-ui/defaults/main.yml
@@ -4,5 +4,5 @@ globex_ui_app_name: globex-ui
 
 globex_ui_name: globex-ui
 globex_ui_replicas: 1
-globex_ui_image: quay.io/globex-recommendation/globex-recommendation-ui:9fedc9b
+globex_ui_image: quay.io/globex-recommendation/globex-recommendation-ui:latest
 globex_ui_node_env: prod


### PR DESCRIPTION
Deployment of the image for globex-ui with image tag "9fedc9b" has been failing when provisioning the workshop, as the image tag does not exist anymore.
https://quay.io/repository/globex-recommendation/globex-recommendation-ui?tab=tags&tag=9fedc9b

This PR updated default value to "latest". 